### PR TITLE
Add -std=c++11 for build_utils.sh

### DIFF
--- a/4-verilog-mu0/build_utils.sh
+++ b/4-verilog-mu0/build_utils.sh
@@ -6,7 +6,7 @@ MU0_SRCS="utils/mu0_assembly.cpp utils/mu0_disassembly.cpp utils/mu0_simulate.cp
 
 echo "Building MU0 utils" > /dev/stderr
 mkdir -p bin
-g++ -o bin/assembler utils/assembler.cpp ${MU0_SRCS}
-g++ -o bin/simulator utils/simulator.cpp ${MU0_SRCS}
-g++ -o bin/disassembler utils/disassembler.cpp ${MU0_SRCS}
+g++ -std=c++11 -o bin/assembler utils/assembler.cpp ${MU0_SRCS}
+g++ -std=c++11 -o bin/simulator utils/simulator.cpp ${MU0_SRCS}
+g++ -std=c++11 -o bin/disassembler utils/disassembler.cpp ${MU0_SRCS}
 echo "  done" > /dev/stderr


### PR DESCRIPTION
fix errors on macos, and still works on linux.